### PR TITLE
fix:go编译选项去掉-i，新增version文件

### DIFF
--- a/echo/tcp-echo/client/app/version.go
+++ b/echo/tcp-echo/client/app/version.go
@@ -1,0 +1,16 @@
+/*
+*****************************************************
+# DESC    : echo stream parser
+# AUTHOR  : Alex Stocks
+# LICENCE : Apache License 2.0
+# EMAIL   : alexstocks@foxmail.com
+# MOD     : 2016-09-04 13:08
+# FILE    : readwriter.go
+*****************************************************
+*/
+
+package main
+
+var (
+	Version = "1.0.0"
+)

--- a/echo/tcp-echo/client/assembly/common/build.sh
+++ b/echo/tcp-echo/client/assembly/common/build.sh
@@ -11,28 +11,28 @@
 
 rm -rf target/
 
-PROJECT_HOME=`pwd`
+PROJECT_HOME=$(pwd)
 TARGET_FOLDER=${PROJECT_HOME}/target/${GOOS}
 
 TARGET_SBIN_NAME=${TARGET_EXEC_NAME}
-version=`cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}'`
+version=$(cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}')
 if [[ ${GOOS} == "windows" ]]; then
     TARGET_SBIN_NAME=${TARGET_SBIN_NAME}.exe
 fi
 TARGET_NAME=${TARGET_FOLDER}/${TARGET_SBIN_NAME}
-if [[ $PROFILE == "dev" ||  $PROFILE == "test" ]]; then
+if [[ $PROFILE == "dev" || $PROFILE == "test" ]]; then
     # GFLAGS=-gcflags "-N -l" -race -x -v # -x会把go build的详细过程输出
     # GFLAGS=-gcflags "-N -l" -race -v
     # GFLAGS="-gcflags \"-N -l\" -v"
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -o ${TARGET_NAME} && cd -
 else
     # -s去掉符号表（然后panic时候的stack trace就没有任何文件名/行号信息了，这个等价于普通C/C++程序被strip的效果），
     # -w去掉DWARF调试信息，得到的程序就不能用gdb调试了。-s和-w也可以分开使用，一般来说如果不打算用gdb调试，
     # -w基本没啥损失。-s的损失就有点大了。
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -o ${TARGET_NAME} && cd -
 fi
 
-TAR_NAME=${TARGET_EXEC_NAME}-${version}-`date "+%Y%m%d-%H%M"`-${PROFILE}
+TAR_NAME=${TARGET_EXEC_NAME}-${version}-$(date "+%Y%m%d-%H%M")-${PROFILE}
 
 mkdir -p ${TARGET_FOLDER}/${TAR_NAME}
 
@@ -74,4 +74,3 @@ cp -r profiles/${PROFILE}/* ${CONF_DIR}
 cd ${TARGET_FOLDER}
 
 tar czf ${TAR_NAME}.tar.gz ${TAR_NAME}/*
-

--- a/echo/tcp-echo/server/app/version.go
+++ b/echo/tcp-echo/server/app/version.go
@@ -1,0 +1,16 @@
+/*
+*****************************************************
+# DESC    : echo stream parser
+# AUTHOR  : Alex Stocks
+# LICENCE : Apache License 2.0
+# EMAIL   : alexstocks@foxmail.com
+# MOD     : 2016-09-04 13:08
+# FILE    : readwriter.go
+*****************************************************
+*/
+
+package main
+
+var (
+	Version = "1.0.0"
+)

--- a/echo/tcp-echo/server/assembly/common/build.sh
+++ b/echo/tcp-echo/server/assembly/common/build.sh
@@ -11,28 +11,28 @@
 
 rm -rf target/
 
-PROJECT_HOME=`pwd`
+PROJECT_HOME=$(pwd)
 TARGET_FOLDER=${PROJECT_HOME}/target/${GOOS}
 
 TARGET_SBIN_NAME=${TARGET_EXEC_NAME}
-version=`cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}'`
+version=$(cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}')
 if [[ ${GOOS} == "windows" ]]; then
     TARGET_SBIN_NAME=${TARGET_SBIN_NAME}.exe
 fi
 TARGET_NAME=${TARGET_FOLDER}/${TARGET_SBIN_NAME}
-if [[ $PROFILE == "dev" ||  $PROFILE == "test" ]]; then
+if [[ $PROFILE == "dev" || $PROFILE == "test" ]]; then
     # GFLAGS=-gcflags "-N -l" -race -x -v # -x会把go build的详细过程输出
     # GFLAGS=-gcflags "-N -l" -race -v
     # GFLAGS="-gcflags \"-N -l\" -v"
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -o ${TARGET_NAME} && cd -
 else
     # -s去掉符号表（然后panic时候的stack trace就没有任何文件名/行号信息了，这个等价于普通C/C++程序被strip的效果），
     # -w去掉DWARF调试信息，得到的程序就不能用gdb调试了。-s和-w也可以分开使用，一般来说如果不打算用gdb调试，
     # -w基本没啥损失。-s的损失就有点大了。
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -o ${TARGET_NAME} && cd -
 fi
 
-TAR_NAME=${TARGET_EXEC_NAME}-${version}-`date "+%Y%m%d-%H%M"`-${PROFILE}
+TAR_NAME=${TARGET_EXEC_NAME}-${version}-$(date "+%Y%m%d-%H%M")-${PROFILE}
 
 mkdir -p ${TARGET_FOLDER}/${TAR_NAME}
 
@@ -74,4 +74,3 @@ cp -r profiles/${PROFILE}/* ${CONF_DIR}
 cd ${TARGET_FOLDER}
 
 tar czf ${TAR_NAME}.tar.gz ${TAR_NAME}/*
-

--- a/echo/udp-echo/client/app/version.go
+++ b/echo/udp-echo/client/app/version.go
@@ -1,0 +1,16 @@
+/*
+*****************************************************
+# DESC    : echo stream parser
+# AUTHOR  : Alex Stocks
+# LICENCE : Apache License 2.0
+# EMAIL   : alexstocks@foxmail.com
+# MOD     : 2016-09-04 13:08
+# FILE    : readwriter.go
+*****************************************************
+*/
+
+package main
+
+var (
+	Version = "1.0.0"
+)

--- a/echo/udp-echo/client/assembly/common/build.sh
+++ b/echo/udp-echo/client/assembly/common/build.sh
@@ -11,28 +11,28 @@
 
 rm -rf target/
 
-PROJECT_HOME=`pwd`
+PROJECT_HOME=$(pwd)
 TARGET_FOLDER=${PROJECT_HOME}/target/${GOOS}
 
 TARGET_SBIN_NAME=${TARGET_EXEC_NAME}
-version=`cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}'`
+version=$(cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}')
 if [[ ${GOOS} == "windows" ]]; then
     TARGET_SBIN_NAME=${TARGET_SBIN_NAME}.exe
 fi
 TARGET_NAME=${TARGET_FOLDER}/${TARGET_SBIN_NAME}
-if [[ $PROFILE == "dev" ||  $PROFILE == "test" ]]; then
+if [[ $PROFILE == "dev" || $PROFILE == "test" ]]; then
     # GFLAGS=-gcflags "-N -l" -race -x -v # -x会把go build的详细过程输出
     # GFLAGS=-gcflags "-N -l" -race -v
     # GFLAGS="-gcflags \"-N -l\" -v"
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -o ${TARGET_NAME} && cd -
 else
     # -s去掉符号表（然后panic时候的stack trace就没有任何文件名/行号信息了，这个等价于普通C/C++程序被strip的效果），
     # -w去掉DWARF调试信息，得到的程序就不能用gdb调试了。-s和-w也可以分开使用，一般来说如果不打算用gdb调试，
     # -w基本没啥损失。-s的损失就有点大了。
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -o ${TARGET_NAME} && cd -
 fi
 
-TAR_NAME=${TARGET_EXEC_NAME}-${version}-`date "+%Y%m%d-%H%M"`-${PROFILE}
+TAR_NAME=${TARGET_EXEC_NAME}-${version}-$(date "+%Y%m%d-%H%M")-${PROFILE}
 
 mkdir -p ${TARGET_FOLDER}/${TAR_NAME}
 
@@ -74,4 +74,3 @@ cp -r profiles/${PROFILE}/* ${CONF_DIR}
 cd ${TARGET_FOLDER}
 
 tar czf ${TAR_NAME}.tar.gz ${TAR_NAME}/*
-

--- a/echo/udp-echo/server/app/version.go
+++ b/echo/udp-echo/server/app/version.go
@@ -1,0 +1,16 @@
+/*
+*****************************************************
+# DESC    : echo stream parser
+# AUTHOR  : Alex Stocks
+# LICENCE : Apache License 2.0
+# EMAIL   : alexstocks@foxmail.com
+# MOD     : 2016-09-04 13:08
+# FILE    : readwriter.go
+*****************************************************
+*/
+
+package main
+
+var (
+	Version = "1.0.0"
+)

--- a/echo/udp-echo/server/assembly/common/build.sh
+++ b/echo/udp-echo/server/assembly/common/build.sh
@@ -11,28 +11,28 @@
 
 rm -rf target/
 
-PROJECT_HOME=`pwd`
+PROJECT_HOME=$(pwd)
 TARGET_FOLDER=${PROJECT_HOME}/target/${GOOS}
 
 TARGET_SBIN_NAME=${TARGET_EXEC_NAME}
-version=`cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}'`
+version=$(cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}')
 if [[ ${GOOS} == "windows" ]]; then
     TARGET_SBIN_NAME=${TARGET_SBIN_NAME}.exe
 fi
 TARGET_NAME=${TARGET_FOLDER}/${TARGET_SBIN_NAME}
-if [[ $PROFILE == "dev" ||  $PROFILE == "test" ]]; then
+if [[ $PROFILE == "dev" || $PROFILE == "test" ]]; then
     # GFLAGS=-gcflags "-N -l" -race -x -v # -x会把go build的详细过程输出
     # GFLAGS=-gcflags "-N -l" -race -v
     # GFLAGS="-gcflags \"-N -l\" -v"
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -o ${TARGET_NAME} && cd -
 else
     # -s去掉符号表（然后panic时候的stack trace就没有任何文件名/行号信息了，这个等价于普通C/C++程序被strip的效果），
     # -w去掉DWARF调试信息，得到的程序就不能用gdb调试了。-s和-w也可以分开使用，一般来说如果不打算用gdb调试，
     # -w基本没啥损失。-s的损失就有点大了。
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -o ${TARGET_NAME} && cd -
 fi
 
-TAR_NAME=${TARGET_EXEC_NAME}-${version}-`date "+%Y%m%d-%H%M"`-${PROFILE}
+TAR_NAME=${TARGET_EXEC_NAME}-${version}-$(date "+%Y%m%d-%H%M")-${PROFILE}
 
 mkdir -p ${TARGET_FOLDER}/${TAR_NAME}
 
@@ -74,4 +74,3 @@ cp -r profiles/${PROFILE}/* ${CONF_DIR}
 cd ${TARGET_FOLDER}
 
 tar czf ${TAR_NAME}.tar.gz ${TAR_NAME}/*
-

--- a/echo/ws-echo/client/app/version.go
+++ b/echo/ws-echo/client/app/version.go
@@ -1,0 +1,16 @@
+/*
+*****************************************************
+# DESC    : echo stream parser
+# AUTHOR  : Alex Stocks
+# LICENCE : Apache License 2.0
+# EMAIL   : alexstocks@foxmail.com
+# MOD     : 2016-09-04 13:08
+# FILE    : readwriter.go
+*****************************************************
+*/
+
+package main
+
+var (
+	Version = "1.0.0"
+)

--- a/echo/ws-echo/client/assembly/common/build.sh
+++ b/echo/ws-echo/client/assembly/common/build.sh
@@ -11,28 +11,28 @@
 
 rm -rf target/
 
-PROJECT_HOME=`pwd`
+PROJECT_HOME=$(pwd)
 TARGET_FOLDER=${PROJECT_HOME}/target/${GOOS}
 
 TARGET_SBIN_NAME=${TARGET_EXEC_NAME}
-version=`cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}'`
+version=$(cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}')
 if [[ ${GOOS} == "windows" ]]; then
     TARGET_SBIN_NAME=${TARGET_SBIN_NAME}.exe
 fi
 TARGET_NAME=${TARGET_FOLDER}/${TARGET_SBIN_NAME}
-if [[ $PROFILE == "dev" ||  $PROFILE == "test" ]]; then
+if [[ $PROFILE == "dev" || $PROFILE == "test" ]]; then
     # GFLAGS=-gcflags "-N -l" -race -x -v # -x会把go build的详细过程输出
     # GFLAGS=-gcflags "-N -l" -race -v
     # GFLAGS="-gcflags \"-N -l\" -v"
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -o ${TARGET_NAME} && cd -
 else
     # -s去掉符号表（然后panic时候的stack trace就没有任何文件名/行号信息了，这个等价于普通C/C++程序被strip的效果），
     # -w去掉DWARF调试信息，得到的程序就不能用gdb调试了。-s和-w也可以分开使用，一般来说如果不打算用gdb调试，
     # -w基本没啥损失。-s的损失就有点大了。
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -o ${TARGET_NAME} && cd -
 fi
 
-TAR_NAME=${TARGET_EXEC_NAME}-${version}-`date "+%Y%m%d-%H%M"`-${PROFILE}
+TAR_NAME=${TARGET_EXEC_NAME}-${version}-$(date "+%Y%m%d-%H%M")-${PROFILE}
 
 mkdir -p ${TARGET_FOLDER}/${TAR_NAME}
 
@@ -74,4 +74,3 @@ cp -r profiles/${PROFILE}/* ${CONF_DIR}
 cd ${TARGET_FOLDER}
 
 tar czf ${TAR_NAME}.tar.gz ${TAR_NAME}/*
-

--- a/echo/ws-echo/server/app/version.go
+++ b/echo/ws-echo/server/app/version.go
@@ -1,0 +1,16 @@
+/*
+*****************************************************
+# DESC    : echo stream parser
+# AUTHOR  : Alex Stocks
+# LICENCE : Apache License 2.0
+# EMAIL   : alexstocks@foxmail.com
+# MOD     : 2016-09-04 13:08
+# FILE    : readwriter.go
+*****************************************************
+*/
+
+package main
+
+var (
+	Version = "1.0.0"
+)

--- a/echo/ws-echo/server/assembly/common/build.sh
+++ b/echo/ws-echo/server/assembly/common/build.sh
@@ -11,28 +11,28 @@
 
 rm -rf target/
 
-PROJECT_HOME=`pwd`
+PROJECT_HOME=$(pwd)
 TARGET_FOLDER=${PROJECT_HOME}/target/${GOOS}
 
 TARGET_SBIN_NAME=${TARGET_EXEC_NAME}
-version=`cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}'`
+version=$(cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}')
 if [[ ${GOOS} == "windows" ]]; then
     TARGET_SBIN_NAME=${TARGET_SBIN_NAME}.exe
 fi
 TARGET_NAME=${TARGET_FOLDER}/${TARGET_SBIN_NAME}
-if [[ $PROFILE == "dev" ||  $PROFILE == "test" ]]; then
+if [[ $PROFILE == "dev" || $PROFILE == "test" ]]; then
     # GFLAGS=-gcflags "-N -l" -race -x -v # -x会把go build的详细过程输出
     # GFLAGS=-gcflags "-N -l" -race -v
     # GFLAGS="-gcflags \"-N -l\" -v"
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -o ${TARGET_NAME} && cd -
 else
     # -s去掉符号表（然后panic时候的stack trace就没有任何文件名/行号信息了，这个等价于普通C/C++程序被strip的效果），
     # -w去掉DWARF调试信息，得到的程序就不能用gdb调试了。-s和-w也可以分开使用，一般来说如果不打算用gdb调试，
     # -w基本没啥损失。-s的损失就有点大了。
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -o ${TARGET_NAME} && cd -
 fi
 
-TAR_NAME=${TARGET_EXEC_NAME}-${version}-`date "+%Y%m%d-%H%M"`-${PROFILE}
+TAR_NAME=${TARGET_EXEC_NAME}-${version}-$(date "+%Y%m%d-%H%M")-${PROFILE}
 
 mkdir -p ${TARGET_FOLDER}/${TAR_NAME}
 
@@ -74,4 +74,3 @@ cp -r profiles/${PROFILE}/* ${CONF_DIR}
 cd ${TARGET_FOLDER}
 
 tar czf ${TAR_NAME}.tar.gz ${TAR_NAME}/*
-

--- a/echo/wss-echo/client/app/version.go
+++ b/echo/wss-echo/client/app/version.go
@@ -1,0 +1,16 @@
+/*
+*****************************************************
+# DESC    : echo stream parser
+# AUTHOR  : Alex Stocks
+# LICENCE : Apache License 2.0
+# EMAIL   : alexstocks@foxmail.com
+# MOD     : 2016-09-04 13:08
+# FILE    : readwriter.go
+*****************************************************
+*/
+
+package main
+
+var (
+	Version = "1.0.0"
+)

--- a/echo/wss-echo/client/assembly/common/build.sh
+++ b/echo/wss-echo/client/assembly/common/build.sh
@@ -11,28 +11,28 @@
 
 rm -rf target/
 
-PROJECT_HOME=`pwd`
+PROJECT_HOME=$(pwd)
 TARGET_FOLDER=${PROJECT_HOME}/target/${GOOS}
 
 TARGET_SBIN_NAME=${TARGET_EXEC_NAME}
-version=`cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}'`
+version=$(cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}')
 if [[ ${GOOS} == "windows" ]]; then
     TARGET_SBIN_NAME=${TARGET_SBIN_NAME}.exe
 fi
 TARGET_NAME=${TARGET_FOLDER}/${TARGET_SBIN_NAME}
-if [[ $PROFILE == "dev" ||  $PROFILE == "test" ]]; then
+if [[ $PROFILE == "dev" || $PROFILE == "test" ]]; then
     # GFLAGS=-gcflags "-N -l" -race -x -v # -x会把go build的详细过程输出
     # GFLAGS=-gcflags "-N -l" -race -v
     # GFLAGS="-gcflags \"-N -l\" -v"
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -o ${TARGET_NAME} && cd -
 else
     # -s去掉符号表（然后panic时候的stack trace就没有任何文件名/行号信息了，这个等价于普通C/C++程序被strip的效果），
     # -w去掉DWARF调试信息，得到的程序就不能用gdb调试了。-s和-w也可以分开使用，一般来说如果不打算用gdb调试，
     # -w基本没啥损失。-s的损失就有点大了。
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -o ${TARGET_NAME} && cd -
 fi
 
-TAR_NAME=${TARGET_EXEC_NAME}-${version}-`date "+%Y%m%d-%H%M"`-${PROFILE}
+TAR_NAME=${TARGET_EXEC_NAME}-${version}-$(date "+%Y%m%d-%H%M")-${PROFILE}
 
 mkdir -p ${TARGET_FOLDER}/${TAR_NAME}
 
@@ -74,4 +74,3 @@ cp -r profiles/${PROFILE}/* ${CONF_DIR}
 cd ${TARGET_FOLDER}
 
 tar czf ${TAR_NAME}.tar.gz ${TAR_NAME}/*
-

--- a/echo/wss-echo/server/app/version.go
+++ b/echo/wss-echo/server/app/version.go
@@ -1,0 +1,16 @@
+/*
+*****************************************************
+# DESC    : echo stream parser
+# AUTHOR  : Alex Stocks
+# LICENCE : Apache License 2.0
+# EMAIL   : alexstocks@foxmail.com
+# MOD     : 2016-09-04 13:08
+# FILE    : readwriter.go
+*****************************************************
+*/
+
+package main
+
+var (
+	Version = "1.0.0"
+)

--- a/echo/wss-echo/server/assembly/common/build.sh
+++ b/echo/wss-echo/server/assembly/common/build.sh
@@ -11,28 +11,28 @@
 
 rm -rf target/
 
-PROJECT_HOME=`pwd`
+PROJECT_HOME=$(pwd)
 TARGET_FOLDER=${PROJECT_HOME}/target/${GOOS}
 
 TARGET_SBIN_NAME=${TARGET_EXEC_NAME}
-version=`cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}'`
+version=$(cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}')
 if [[ ${GOOS} == "windows" ]]; then
     TARGET_SBIN_NAME=${TARGET_SBIN_NAME}.exe
 fi
 TARGET_NAME=${TARGET_FOLDER}/${TARGET_SBIN_NAME}
-if [[ $PROFILE == "dev" ||  $PROFILE == "test" ]]; then
+if [[ $PROFILE == "dev" || $PROFILE == "test" ]]; then
     # GFLAGS=-gcflags "-N -l" -race -x -v # -x会把go build的详细过程输出
     # GFLAGS=-gcflags "-N -l" -race -v
     # GFLAGS="-gcflags \"-N -l\" -v"
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -o ${TARGET_NAME} && cd -
 else
     # -s去掉符号表（然后panic时候的stack trace就没有任何文件名/行号信息了，这个等价于普通C/C++程序被strip的效果），
     # -w去掉DWARF调试信息，得到的程序就不能用gdb调试了。-s和-w也可以分开使用，一般来说如果不打算用gdb调试，
     # -w基本没啥损失。-s的损失就有点大了。
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -o ${TARGET_NAME} && cd -
 fi
 
-TAR_NAME=${TARGET_EXEC_NAME}-${version}-`date "+%Y%m%d-%H%M"`-${PROFILE}
+TAR_NAME=${TARGET_EXEC_NAME}-${version}-$(date "+%Y%m%d-%H%M")-${PROFILE}
 
 mkdir -p ${TARGET_FOLDER}/${TAR_NAME}
 
@@ -74,4 +74,3 @@ cp -r profiles/${PROFILE}/* ${CONF_DIR}
 cd ${TARGET_FOLDER}
 
 tar czf ${TAR_NAME}.tar.gz ${TAR_NAME}/*
-

--- a/micro/client/app/version.go
+++ b/micro/client/app/version.go
@@ -1,0 +1,16 @@
+/*
+*****************************************************
+# DESC    : echo stream parser
+# AUTHOR  : Alex Stocks
+# LICENCE : Apache License 2.0
+# EMAIL   : alexstocks@foxmail.com
+# MOD     : 2016-09-04 13:08
+# FILE    : readwriter.go
+*****************************************************
+*/
+
+package main
+
+var (
+	Version = "1.0.0"
+)

--- a/micro/client/assembly/common/build.sh
+++ b/micro/client/assembly/common/build.sh
@@ -11,28 +11,28 @@
 
 rm -rf target/
 
-PROJECT_HOME=`pwd`
+PROJECT_HOME=$(pwd)
 TARGET_FOLDER=${PROJECT_HOME}/target/${GOOS}
 
 TARGET_SBIN_NAME=${TARGET_EXEC_NAME}
-version=`cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}'`
+version=$(cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}')
 if [[ ${GOOS} == "windows" ]]; then
     TARGET_SBIN_NAME=${TARGET_SBIN_NAME}.exe
 fi
 TARGET_NAME=${TARGET_FOLDER}/${TARGET_SBIN_NAME}
-if [[ $PROFILE == "dev" ||  $PROFILE == "test" ]]; then
+if [[ $PROFILE == "dev" || $PROFILE == "test" ]]; then
     # GFLAGS=-gcflags "-N -l" -race -x -v # -x会把go build的详细过程输出
     # GFLAGS=-gcflags "-N -l" -race -v
     # GFLAGS="-gcflags \"-N -l\" -v"
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -o ${TARGET_NAME} && cd -
 else
     # -s去掉符号表（然后panic时候的stack trace就没有任何文件名/行号信息了，这个等价于普通C/C++程序被strip的效果），
     # -w去掉DWARF调试信息，得到的程序就不能用gdb调试了。-s和-w也可以分开使用，一般来说如果不打算用gdb调试，
     # -w基本没啥损失。-s的损失就有点大了。
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -o ${TARGET_NAME} && cd -
 fi
 
-TAR_NAME=${TARGET_EXEC_NAME}-${version}-`date "+%Y%m%d-%H%M"`-${PROFILE}
+TAR_NAME=${TARGET_EXEC_NAME}-${version}-$(date "+%Y%m%d-%H%M")-${PROFILE}
 
 mkdir -p ${TARGET_FOLDER}/${TAR_NAME}
 
@@ -74,4 +74,3 @@ cp -r profiles/${PROFILE}/* ${CONF_DIR}
 cd ${TARGET_FOLDER}
 
 tar czf ${TAR_NAME}.tar.gz ${TAR_NAME}/*
-

--- a/micro/server/app/version.go
+++ b/micro/server/app/version.go
@@ -1,0 +1,16 @@
+/*
+*****************************************************
+# DESC    : echo stream parser
+# AUTHOR  : Alex Stocks
+# LICENCE : Apache License 2.0
+# EMAIL   : alexstocks@foxmail.com
+# MOD     : 2016-09-04 13:08
+# FILE    : readwriter.go
+*****************************************************
+*/
+
+package main
+
+var (
+	Version = "1.0.0"
+)

--- a/micro/server/assembly/common/build.sh
+++ b/micro/server/assembly/common/build.sh
@@ -11,28 +11,28 @@
 
 rm -rf target/
 
-PROJECT_HOME=`pwd`
+PROJECT_HOME=$(pwd)
 TARGET_FOLDER=${PROJECT_HOME}/target/${GOOS}
 
 TARGET_SBIN_NAME=${TARGET_EXEC_NAME}
-version=`cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}'`
+version=$(cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}')
 if [[ ${GOOS} == "windows" ]]; then
     TARGET_SBIN_NAME=${TARGET_SBIN_NAME}.exe
 fi
 TARGET_NAME=${TARGET_FOLDER}/${TARGET_SBIN_NAME}
-if [[ $PROFILE == "dev" ||  $PROFILE == "test" ]]; then
+if [[ $PROFILE == "dev" || $PROFILE == "test" ]]; then
     # GFLAGS=-gcflags "-N -l" -race -x -v # -x会把go build的详细过程输出
     # GFLAGS=-gcflags "-N -l" -race -v
     # GFLAGS="-gcflags \"-N -l\" -v"
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -o ${TARGET_NAME} && cd -
 else
     # -s去掉符号表（然后panic时候的stack trace就没有任何文件名/行号信息了，这个等价于普通C/C++程序被strip的效果），
     # -w去掉DWARF调试信息，得到的程序就不能用gdb调试了。-s和-w也可以分开使用，一般来说如果不打算用gdb调试，
     # -w基本没啥损失。-s的损失就有点大了。
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -o ${TARGET_NAME} && cd -
 fi
 
-TAR_NAME=${TARGET_EXEC_NAME}-${version}-`date "+%Y%m%d-%H%M"`-${PROFILE}
+TAR_NAME=${TARGET_EXEC_NAME}-${version}-$(date "+%Y%m%d-%H%M")-${PROFILE}
 
 mkdir -p ${TARGET_FOLDER}/${TAR_NAME}
 
@@ -74,4 +74,3 @@ cp -r profiles/${PROFILE}/* ${CONF_DIR}
 cd ${TARGET_FOLDER}
 
 tar czf ${TAR_NAME}.tar.gz ${TAR_NAME}/*
-

--- a/rpc/client/app/version.go
+++ b/rpc/client/app/version.go
@@ -1,0 +1,16 @@
+/*
+*****************************************************
+# DESC    : echo stream parser
+# AUTHOR  : Alex Stocks
+# LICENCE : Apache License 2.0
+# EMAIL   : alexstocks@foxmail.com
+# MOD     : 2016-09-04 13:08
+# FILE    : readwriter.go
+*****************************************************
+*/
+
+package main
+
+var (
+	Version = "1.0.0"
+)

--- a/rpc/client/assembly/common/build.sh
+++ b/rpc/client/assembly/common/build.sh
@@ -11,28 +11,28 @@
 
 rm -rf target/
 
-PROJECT_HOME=`pwd`
+PROJECT_HOME=$(pwd)
 TARGET_FOLDER=${PROJECT_HOME}/target/${GOOS}
 
 TARGET_SBIN_NAME=${TARGET_EXEC_NAME}
-version=`cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}'`
+version=$(cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}')
 if [[ ${GOOS} == "windows" ]]; then
     TARGET_SBIN_NAME=${TARGET_SBIN_NAME}.exe
 fi
 TARGET_NAME=${TARGET_FOLDER}/${TARGET_SBIN_NAME}
-if [[ $PROFILE == "dev" ||  $PROFILE == "test" ]]; then
+if [[ $PROFILE == "dev" || $PROFILE == "test" ]]; then
     # GFLAGS=-gcflags "-N -l" -race -x -v # -x会把go build的详细过程输出
     # GFLAGS=-gcflags "-N -l" -race -v
     # GFLAGS="-gcflags \"-N -l\" -v"
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -o ${TARGET_NAME} && cd -
 else
     # -s去掉符号表（然后panic时候的stack trace就没有任何文件名/行号信息了，这个等价于普通C/C++程序被strip的效果），
     # -w去掉DWARF调试信息，得到的程序就不能用gdb调试了。-s和-w也可以分开使用，一般来说如果不打算用gdb调试，
     # -w基本没啥损失。-s的损失就有点大了。
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -o ${TARGET_NAME} && cd -
 fi
 
-TAR_NAME=${TARGET_EXEC_NAME}-${version}-`date "+%Y%m%d-%H%M"`-${PROFILE}
+TAR_NAME=${TARGET_EXEC_NAME}-${version}-$(date "+%Y%m%d-%H%M")-${PROFILE}
 
 mkdir -p ${TARGET_FOLDER}/${TAR_NAME}
 
@@ -74,4 +74,3 @@ cp -r profiles/${PROFILE}/* ${CONF_DIR}
 cd ${TARGET_FOLDER}
 
 tar czf ${TAR_NAME}.tar.gz ${TAR_NAME}/*
-

--- a/rpc/server/app/version.go
+++ b/rpc/server/app/version.go
@@ -1,0 +1,16 @@
+/*
+*****************************************************
+# DESC    : echo stream parser
+# AUTHOR  : Alex Stocks
+# LICENCE : Apache License 2.0
+# EMAIL   : alexstocks@foxmail.com
+# MOD     : 2016-09-04 13:08
+# FILE    : readwriter.go
+*****************************************************
+*/
+
+package main
+
+var (
+	Version = "1.0.0"
+)

--- a/rpc/server/assembly/common/build.sh
+++ b/rpc/server/assembly/common/build.sh
@@ -11,28 +11,28 @@
 
 rm -rf target/
 
-PROJECT_HOME=`pwd`
+PROJECT_HOME=$(pwd)
 TARGET_FOLDER=${PROJECT_HOME}/target/${GOOS}
 
 TARGET_SBIN_NAME=${TARGET_EXEC_NAME}
-version=`cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}'`
+version=$(cat app/version.go | grep Version | awk -F '=' '{print $2}' | awk -F '"' '{print $2}')
 if [[ ${GOOS} == "windows" ]]; then
     TARGET_SBIN_NAME=${TARGET_SBIN_NAME}.exe
 fi
 TARGET_NAME=${TARGET_FOLDER}/${TARGET_SBIN_NAME}
-if [[ $PROFILE == "dev" ||  $PROFILE == "test" ]]; then
+if [[ $PROFILE == "dev" || $PROFILE == "test" ]]; then
     # GFLAGS=-gcflags "-N -l" -race -x -v # -x会把go build的详细过程输出
     # GFLAGS=-gcflags "-N -l" -race -v
     # GFLAGS="-gcflags \"-N -l\" -v"
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -gcflags "-N -l" -x -v -o ${TARGET_NAME} && cd -
 else
     # -s去掉符号表（然后panic时候的stack trace就没有任何文件名/行号信息了，这个等价于普通C/C++程序被strip的效果），
     # -w去掉DWARF调试信息，得到的程序就不能用gdb调试了。-s和-w也可以分开使用，一般来说如果不打算用gdb调试，
     # -w基本没啥损失。-s的损失就有点大了。
-    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -i -o ${TARGET_NAME} && cd -
+    cd ${BUILD_PACKAGE} && GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w" -x -v -o ${TARGET_NAME} && cd -
 fi
 
-TAR_NAME=${TARGET_EXEC_NAME}-${version}-`date "+%Y%m%d-%H%M"`-${PROFILE}
+TAR_NAME=${TARGET_EXEC_NAME}-${version}-$(date "+%Y%m%d-%H%M")-${PROFILE}
 
 mkdir -p ${TARGET_FOLDER}/${TAR_NAME}
 
@@ -74,4 +74,3 @@ cp -r profiles/${PROFILE}/* ${CONF_DIR}
 cd ${TARGET_FOLDER}
 
 tar czf ${TAR_NAME}.tar.gz ${TAR_NAME}/*
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `version.go` files across multiple components, establishing a versioning mechanism set to "1.0.0".
  
- **Bug Fixes**
	- Updated build scripts to enhance readability and maintainability by replacing backticks with `$()` for command substitution.
	- Removed the `-i` flag from `go build` commands in build scripts to improve dependency handling during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->