### PR TITLE
update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -102,7 +102,7 @@ $ cd target/darwin/rpc_server-${your-version}-${current-time}-test/ && sh bin/lo
 $ cd rpc/client/ && sh assembly/mac/test.sh
 // your_version is the version of getty, current-time is the time when you compile the code.
 // please replace your_version and current-time with the real version and time.
-cd target/darwin/rpc_client-${your-version}-${current-time}-test/ && sh bin/load_rpc_client.sh start
+$ cd target/darwin/rpc_client-${your-version}-${current-time}-test/ && sh bin/load_rpc_client.sh start
 ```
 
 ## getty example4: micro ##

--- a/readme.md
+++ b/readme.md
@@ -19,13 +19,19 @@ The server sends back messages from client. The client sends messages to the ech
 To run the example, start the server:
 
 ```bash
-$ cd echo/tcp-echo/server/ && sh assembly/linux/test.sh && cd target/linux/echo_server-0.3.07-20161009-1632-test/ && sh bin/load.sh start
+$ cd echo/tcp-echo/server/ && sh assembly/linux/test.sh
+// your_version is the version of getty, current-time is the time when you compile the code.
+// please replace your_version and current-time with the real version and time.
+$ cd target/linux/echo_server-${your-version}-${current-time}-test/ && sh bin/load_echo_server.sh start
 ```
 
 Next, start the client:
 
 ```bash
-$ cd echo/tcp-echo/client/ && sh assembly/linux/test.sh && cd target/linux/echo_client-0.3.07-20161009-1634-test/ && sh bin/load.sh start
+$ cd echo/tcp-echo/client/ && sh assembly/linux/test.sh
+// your_version is the version of getty, current-time is the time when you compile the code.
+// please replace your_version and current-time with the real version and time.
+$ cd target/linux/echo_client-${your-version}-${current-time}-test/ && sh bin/load_echo_client.sh start
 ```
 
 ## getty example2: ws-echo ##
@@ -38,13 +44,19 @@ The server sends back messages from client. The client sends messages to the ech
 To run the example, start the server:
 
 ```bash
-$ cd echo/ws-echo/server/ && sh assembly/linux/test.sh && cd target/linux/echo_server-0.3.07-20161009-1632-test/ && sh bin/load.sh start
+$ cd echo/ws-echo/server/ && sh assembly/linux/test.sh
+// your_version is the version of getty, current-time is the time when you compile the code.
+// please replace your_version and current-time with the real version and time.
+$ cd target/linux/echo_server-${your-version}-${current-time}-test/ && sh bin/load_echo_server.sh start
 ```
 
 Next, start the go client:
 
 ```bash
-$ cd echo/ws-echo/client/ && sh assembly/linux/test.sh && cd target/linux/echo_client-0.3.07-20161009-1634-test/ && sh bin/load.sh start
+$ cd echo/ws-echo/client/ && sh assembly/linux/test.sh
+// your_version is the version of getty, current-time is the time when you compile the code.
+// please replace your_version and current-time with the real version and time.
+$ cd target/linux/echo_client-${your-version}-${current-time}-test/ && sh bin/load_echo_client.sh start
 ```
 
 Or start the js client:
@@ -64,20 +76,31 @@ The server sends back rpc response to client. The client sends rpc requests to t
 To run the example on linux, start the server:
 
 ```bash
-$ cd rpc/server/ && sh assembly/linux/test.sh && cd target/linux/rpc_server-0.9.2-20180806-1559-test/ && sh bin/load.sh start
+$ cd rpc/server/ && sh assembly/linux/test.sh
+// your_version is the version of getty, current-time is the time when you compile the code.
+// please replace your_version and current-time with the real version and time.
+$ cd target/linux/rpc_server-${your-version}-${current-time}-test/ && sh bin/load_rpc_server.sh start
 ```
 
 Next, start the go client:
 
 ```bash
-$ cd rpc/client/ && sh assembly/linux/test.sh && cd target/linux/rpc_client-0.9.2-20180806-1559-test/ && sh bin/load.sh start
+$ cd rpc/client/ && sh assembly/linux/test.sh
+$ cd target/linux/rpc_client-${your-version}-${current-time}-test/ && sh bin/load_rpc_client.sh start
 ```
 
 What's more, if you run this example on mac, the server compile command should be:
 
 ```bash
-$ cd rpc/server/ && sh assembly/mac/test.sh && cd target/darwin/rpc_server-0.9.2-20180806-1559-test/ && sh bin/load.sh start
-$ cd rpc/client/ && sh assembly/mac/test.sh && cd target/darwin/rpc_client-0.9.2-20180806-1559-test/ && sh bin/load.sh start
+$ cd rpc/server/ && sh assembly/mac/test.sh
+// your_version is the version of getty, current-time is the time when you compile the code.
+// please replace your_version and current-time with the real version and time.
+$ cd target/darwin/rpc_server-${your-version}-${current-time}-test/ && sh bin/load_rpc_server.sh start
+
+$ cd rpc/client/ && sh assembly/mac/test.sh
+// your_version is the version of getty, current-time is the time when you compile the code.
+// please replace your_version and current-time with the real version and time.
+cd target/darwin/rpc_client-${your-version}-${current-time}-test/ && sh bin/load_rpc_client.sh start
 ```
 
 ## getty example4: micro ##
@@ -88,18 +111,31 @@ This example shows how to build micro client and server to do service registrati
 To run the example on linux, start the server:
 
 ```bash
-$ cd micro/server/ && sh assembly/linux/test.sh && cd target/linux/micro_server-0.9.2-20180806-1559-test/ && sh bin/load.sh start
+$ cd micro/server/ && sh assembly/linux/test.sh
+// your_version is the version of getty, current-time is the time when you compile the code.
+// please replace your_version and current-time with the real version and time.
+$ cd target/linux/micro_server-${your-version}-${current-time}-test/ && sh bin/load_micro_server.sh start
 ```
 
 Next, start the go client:
 
 ```bash
-$ cd micro/client/ && sh assembly/linux/test.sh && cd target/linux/micro_client-0.9.2-20180806-1559-test/ && sh bin/load.sh start
+$ cd micro/client/ && sh assembly/linux/test.sh
+// your_version is the version of getty, current-time is the time when you compile the code.
+// please replace your_version and current-time with the real version and time.
+$ cd target/linux/micro_client-${your-version}-${current-time}-test/ && sh bin/load_micro_client.sh start
 ```
 
 What's more, if you run this example on mac, the server compile command should be:
 
 ```bash
-$ cd micro/server/ && sh assembly/mac/test.sh && cd target/darwin/micro_server-0.9.2-20180806-1559-test/ && sh bin/load.sh start
-$ cd micro/client/ && sh assembly/mac/test.sh && cd target/darwin/micro_client-0.9.2-20180806-1559-test/ && sh bin/load.sh start
+$ cd micro/server/ && sh assembly/mac/test.sh
+// your_version is the version of getty, current-time is the time when you compile the code.
+// please replace your_version and current-time with the real version and time.
+$ cd target/darwin/micro_server-${your-version}-${current-time}-test/ && sh bin/load_micro_server.sh start
+
+$ cd micro/client/ && sh assembly/mac/test.sh
+// your_version is the version of getty, current-time is the time when you compile the code.
+// please replace your_version and current-time with the real version and time.
+$ cd target/darwin/micro_client-${your-version}-${current-time}-test/ && sh bin/load_micro_client.sh start
 ```

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,8 @@ Next, start the go client:
 
 ```bash
 $ cd rpc/client/ && sh assembly/linux/test.sh
+// your_version is the version of getty, current-time is the time when you compile the code.
+// please replace your_version and current-time with the real version and time.
 $ cd target/linux/rpc_client-${your-version}-${current-time}-test/ && sh bin/load_rpc_client.sh start
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ To run the example, start the server:
 
 ```bash
 $ cd echo/tcp-echo/server/ && sh assembly/linux/test.sh
-// your_version is the version of getty, current-time is the time when you compile the code.
+// your_version is the version set in version.go, current-time is the time when you compile the code.
 // please replace your_version and current-time with the real version and time.
 $ cd target/linux/echo_server-${your-version}-${current-time}-test/ && sh bin/load_echo_server.sh start
 ```
@@ -29,7 +29,7 @@ Next, start the client:
 
 ```bash
 $ cd echo/tcp-echo/client/ && sh assembly/linux/test.sh
-// your_version is the version of getty, current-time is the time when you compile the code.
+// your_version is the version set in version.go, current-time is the time when you compile the code.
 // please replace your_version and current-time with the real version and time.
 $ cd target/linux/echo_client-${your-version}-${current-time}-test/ && sh bin/load_echo_client.sh start
 ```
@@ -45,7 +45,7 @@ To run the example, start the server:
 
 ```bash
 $ cd echo/ws-echo/server/ && sh assembly/linux/test.sh
-// your_version is the version of getty, current-time is the time when you compile the code.
+// your_version is the version set in version.go, current-time is the time when you compile the code.
 // please replace your_version and current-time with the real version and time.
 $ cd target/linux/echo_server-${your-version}-${current-time}-test/ && sh bin/load_echo_server.sh start
 ```
@@ -54,7 +54,7 @@ Next, start the go client:
 
 ```bash
 $ cd echo/ws-echo/client/ && sh assembly/linux/test.sh
-// your_version is the version of getty, current-time is the time when you compile the code.
+// your_version is the version set in version.go, current-time is the time when you compile the code.
 // please replace your_version and current-time with the real version and time.
 $ cd target/linux/echo_client-${your-version}-${current-time}-test/ && sh bin/load_echo_client.sh start
 ```
@@ -77,7 +77,7 @@ To run the example on linux, start the server:
 
 ```bash
 $ cd rpc/server/ && sh assembly/linux/test.sh
-// your_version is the version of getty, current-time is the time when you compile the code.
+// your_version is the version set in version.go, current-time is the time when you compile the code.
 // please replace your_version and current-time with the real version and time.
 $ cd target/linux/rpc_server-${your-version}-${current-time}-test/ && sh bin/load_rpc_server.sh start
 ```
@@ -86,7 +86,7 @@ Next, start the go client:
 
 ```bash
 $ cd rpc/client/ && sh assembly/linux/test.sh
-// your_version is the version of getty, current-time is the time when you compile the code.
+// your_version is the version set in version.go, current-time is the time when you compile the code.
 // please replace your_version and current-time with the real version and time.
 $ cd target/linux/rpc_client-${your-version}-${current-time}-test/ && sh bin/load_rpc_client.sh start
 ```
@@ -95,12 +95,12 @@ What's more, if you run this example on mac, the server compile command should b
 
 ```bash
 $ cd rpc/server/ && sh assembly/mac/test.sh
-// your_version is the version of getty, current-time is the time when you compile the code.
+// your_version is the version set in version.go, current-time is the time when you compile the code.
 // please replace your_version and current-time with the real version and time.
 $ cd target/darwin/rpc_server-${your-version}-${current-time}-test/ && sh bin/load_rpc_server.sh start
 
 $ cd rpc/client/ && sh assembly/mac/test.sh
-// your_version is the version of getty, current-time is the time when you compile the code.
+// your_version is the version set in version.go, current-time is the time when you compile the code.
 // please replace your_version and current-time with the real version and time.
 $ cd target/darwin/rpc_client-${your-version}-${current-time}-test/ && sh bin/load_rpc_client.sh start
 ```
@@ -114,7 +114,7 @@ To run the example on linux, start the server:
 
 ```bash
 $ cd micro/server/ && sh assembly/linux/test.sh
-// your_version is the version of getty, current-time is the time when you compile the code.
+// your_version is the version set in version.go, current-time is the time when you compile the code.
 // please replace your_version and current-time with the real version and time.
 $ cd target/linux/micro_server-${your-version}-${current-time}-test/ && sh bin/load_micro_server.sh start
 ```
@@ -123,7 +123,7 @@ Next, start the go client:
 
 ```bash
 $ cd micro/client/ && sh assembly/linux/test.sh
-// your_version is the version of getty, current-time is the time when you compile the code.
+// your_version is the version set in version.go, current-time is the time when you compile the code.
 // please replace your_version and current-time with the real version and time.
 $ cd target/linux/micro_client-${your-version}-${current-time}-test/ && sh bin/load_micro_client.sh start
 ```
@@ -132,12 +132,12 @@ What's more, if you run this example on mac, the server compile command should b
 
 ```bash
 $ cd micro/server/ && sh assembly/mac/test.sh
-// your_version is the version of getty, current-time is the time when you compile the code.
+// your_version is the version set in version.go, current-time is the time when you compile the code.
 // please replace your_version and current-time with the real version and time.
 $ cd target/darwin/micro_server-${your-version}-${current-time}-test/ && sh bin/load_micro_server.sh start
 
 $ cd micro/client/ && sh assembly/mac/test.sh
-// your_version is the version of getty, current-time is the time when you compile the code.
+// your_version is the version set in version.go, current-time is the time when you compile the code.
 // please replace your_version and current-time with the real version and time.
 $ cd target/darwin/micro_client-${your-version}-${current-time}-test/ && sh bin/load_micro_client.sh start
 ```


### PR DESCRIPTION
Fix the cmd that failed to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated instructions in the `readme.md` for running examples, replacing specific version numbers and timestamps with placeholders for improved flexibility.
	- Added comments to guide users on replacing placeholders with actual values.
	- Minor formatting adjustments for consistency and clarity across examples for Linux and macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->